### PR TITLE
[PSYS-172] Remove TLS Enforce

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -118,7 +118,6 @@ abstract class AbstractRequest extends CommonAbstractRequest
             $this->getEndpoint(),
             $headers,
             $body ?: null,
-            '1.2' // Enforce TLS v1.2
         );
 
         $content = $httpResponse->getBody()->getContents();

--- a/src/Message/PurchaseResponse.php
+++ b/src/Message/PurchaseResponse.php
@@ -139,8 +139,7 @@ class PurchaseResponse extends AbstractResponse
     public function getCode(): ?string
     {
         return implode(' ', [
-            $this->getResponseCode(),
-            $this->getResponseText(),
+            $this->getResponseMessage(),
             '(' . $this->getHttpResponseCode(),
             $this->getHttpResponseCodeText() . ')',
         ]);
@@ -170,20 +169,9 @@ class PurchaseResponse extends AbstractResponse
         return $this->getErrorDataItem('fieldValue');
     }
 
-    /**
-     * Get Payway Response Code
-     */
-    public function getResponseCode(): ?string
+    public function getResponseMessage(): ?string
     {
-        return $this->getDataItem('responseCode');
-    }
-
-    /**
-     * Get Payway Response Text
-     */
-    public function getResponseText(): ?string
-    {
-        return $this->getDataItem('responseText');
+        return $this->getDataItem('responseMessage');
     }
 
     public function getRequestId(): ?string

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -154,8 +154,7 @@ class Response extends AbstractResponse
     public function getCode(): ?string
     {
         return implode(' ', [
-            $this->getResponseCode(),
-            $this->getResponseText(),
+            $this->getResponseMessage(),
             '(' . $this->getHttpResponseCode(),
             $this->getHttpResponseCodeText() . ')',
         ]);
@@ -185,20 +184,9 @@ class Response extends AbstractResponse
         return $this->getErrorDataItem('fieldValue');
     }
 
-    /**
-     * Get Payway Response Code
-     */
-    public function getResponseCode(): string
+    public function getResponseMessage(): ?string
     {
-        return $this->getDataItem('responseCode');
-    }
-
-    /**
-     * Get Payway Response Text
-     */
-    public function getResponseText(): string
-    {
-        return $this->getDataItem('responseText');
+        return $this->getDataItem('message');
     }
 
     public function getRequestId(): ?string


### PR DESCRIPTION
### Fix PSYS-172
Link to ticket: https://digistorm.atlassian.net/browse/PSYS-172

Similar to the westpac TLS problem - obsolete code trying to enforce tls 1.2 that doesn't work
Some carryover westpac payway response logic was failing type checking as the props don't actually exist - replaced.

Once merged, will iterate the version and push the tag.