### PR TITLE
[PSYS-93] Change Response Body Stringify

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -120,7 +120,7 @@ abstract class AbstractRequest extends CommonAbstractRequest
             $body ?: null,
         );
 
-        $content = $httpResponse->getBody()->getContents();
+        $content = (string)$httpResponse->getBody();
 
         $response = new Response($this, json_decode($content, true));
 


### PR DESCRIPTION
### Fix PSYS-93
Link to ticket: https://digistorm.atlassian.net/browse/PSYS-93

Changes stringification of the guzzle response in case preceding debugging or other response handling has already touched the stream.  Using this method gathers the whole response rather than interacting with the stream.